### PR TITLE
Change the Spezi icon in Onboarding to a star

### DIFF
--- a/CS342ExampleApplication/Onboarding/Welcome.swift
+++ b/CS342ExampleApplication/Onboarding/Welcome.swift
@@ -21,11 +21,7 @@ struct Welcome: View {
             areas: [
                 OnboardingInformationView.Content(
                     icon: {
-<<<<<<< HEAD
                         Image(systemName: "staroflife.fill")
-=======
-                        Image(systemName: "cat.fill")
->>>>>>> c01cd8b3f4215dcbe9a6803691bc60de14e8af8d
                             .accessibilityHidden(true)
                     },
                     title: "Cats are great!",

--- a/CS342ExampleApplication/Onboarding/Welcome.swift
+++ b/CS342ExampleApplication/Onboarding/Welcome.swift
@@ -21,7 +21,7 @@ struct Welcome: View {
             areas: [
                 OnboardingInformationView.Content(
                     icon: {
-                        Image(systemName: "apps.iphone")
+                        Image(systemName: "staroflife.fill")
                             .accessibilityHidden(true)
                     },
                     title: "The Spezi Framework",


### PR DESCRIPTION
# Change the Spezi icon in Onboarding to a star

## :recycle: Current situation & Problem
The current Spezi icon is an iPhone which is boring.


## :gear: Release Notes 
This PR changes the icon to a star, which is much cooler looking. It also serves as a great demo for how to resolve a merge conflict in class.


## :books: Documentation
- N/A


## :white_check_mark: Testing
- N/A


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).
